### PR TITLE
Crash when ProgressBarStyle lacks both knob and knobBefore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,75 @@
+
+### Java ###
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+
+### Eclipse ###
+*.pydevproject
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+### gdx-skineditor
+assets/projects

--- a/core/src/org/shadebob/skineditor/NewFontDialog.java
+++ b/core/src/org/shadebob/skineditor/NewFontDialog.java
@@ -188,12 +188,6 @@ public class NewFontDialog extends Dialog {
 
 		});
 		
-		textFontName.setTextFieldListener(new TextFieldListener() {
-			@Override public void keyTyped(TextField textField, char c) {
-				refreshFontPreview(textField.getText());
-			}
-		});
-		
 		refreshFontPreview();
 
 		getContentTable().add(table).width(520).height(320).pad(20);
@@ -211,9 +205,9 @@ public class NewFontDialog extends Dialog {
 					return;
 				}
 				
-				
-				FileHandle handleFont = new FileHandle(System.getProperty("java.io.tmpdir")).child(textFontName.getText() + ".fnt");
-				FileHandle handleImage = new FileHandle(System.getProperty("java.io.tmpdir")).child(textFontName.getText() + ".png");
+				String properFontName = generateProperFontName(selectFonts.getSelected());
+				FileHandle handleFont = new FileHandle(System.getProperty("java.io.tmpdir")).child(properFontName + ".fnt");
+				FileHandle handleImage = new FileHandle(System.getProperty("java.io.tmpdir")).child(properFontName + ".png");
 				
 				FileHandle targetFont = Gdx.files.local("projects/" + game.screenMain.getcurrentProject() + "/" + textFontName.getText() + ".fnt");
 				FileHandle targetImage = Gdx.files.local("projects/" + game.screenMain.getcurrentProject() + "/assets/" + textFontName.getText() + ".png");
@@ -261,10 +255,6 @@ public class NewFontDialog extends Dialog {
 	 * 
 	 */
 	public void refreshFontPreview() {
-		refreshFontPreview(null);
-	}
-	
-	public void refreshFontPreview(String newFontName) {
 
 		try {
 			String fontName = selectFonts.getSelected();
@@ -298,20 +288,9 @@ public class NewFontDialog extends Dialog {
 			
 			unicodeFont.addAsciiGlyphs();
 			
-			if(newFontName == null || newFontName.trim().equals("")) {
+			String newFontName = generateProperFontName(fontName);
 
-				// Generate a temporary name for your font (Do not end with a number, it will be removed in the atlas)
-				newFontName = "font_"+fontName.toLowerCase().replace(" ", "_") +"_"+selectSize.getSelected()+"pt";
-				if (checkBold.isChecked() == true) {
-					newFontName += "_bold";
-				}
-				
-				if (checkItalic.isChecked() == true) {
-					newFontName += "_italic";
-				}
-				
-				textFontName.setText(newFontName);
-			}
+			textFontName.setText(newFontName);
 			
 			// Create bitmap font
 			BMFontUtil bfu = new BMFontUtil(unicodeFont);
@@ -341,5 +320,19 @@ public class NewFontDialog extends Dialog {
 			// Have to do this to force clipping of font
 			textFontPreview.setText(textFontPreview.getText());
 		}
+	}
+	
+	private String generateProperFontName(String originalFontName) {
+		// Generate a temporary name for your font (Do not end with a number, it will be removed in the atlas)
+		String newFontName = "font_"+originalFontName.toLowerCase().replace(" ", "_") +"_"+selectSize.getSelected()+"pt";
+		if (checkBold.isChecked() == true) {
+			newFontName += "_bold";
+		}
+		
+		if (checkItalic.isChecked() == true) {
+			newFontName += "_italic";
+		}
+		
+		return newFontName;
 	}
 }

--- a/core/src/org/shadebob/skineditor/NewFontDialog.java
+++ b/core/src/org/shadebob/skineditor/NewFontDialog.java
@@ -32,6 +32,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
+import com.badlogic.gdx.scenes.scene2d.ui.TextField.TextFieldListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.tools.hiero.BMFontUtil;
 import com.badlogic.gdx.tools.hiero.unicodefont.UnicodeFont;
@@ -187,6 +188,12 @@ public class NewFontDialog extends Dialog {
 
 		});
 		
+		textFontName.setTextFieldListener(new TextFieldListener() {
+			@Override public void keyTyped(TextField textField, char c) {
+				refreshFontPreview(textField.getText());
+			}
+		});
+		
 		refreshFontPreview();
 
 		getContentTable().add(table).width(520).height(320).pad(20);
@@ -254,6 +261,10 @@ public class NewFontDialog extends Dialog {
 	 * 
 	 */
 	public void refreshFontPreview() {
+		refreshFontPreview(null);
+	}
+	
+	public void refreshFontPreview(String newFontName) {
 
 		try {
 			String fontName = selectFonts.getSelected();
@@ -287,19 +298,20 @@ public class NewFontDialog extends Dialog {
 			
 			unicodeFont.addAsciiGlyphs();
 			
+			if(newFontName == null || newFontName.trim().equals("")) {
 
-			// Generate a temporary name for your font (Do not end with a number, it will be removed in the atlas)
-			String newFontName = "font_"+fontName.toLowerCase().replace(" ", "_") +"_"+selectSize.getSelected()+"pt";
-			if (checkBold.isChecked() == true) {
-				newFontName += "_bold";
+				// Generate a temporary name for your font (Do not end with a number, it will be removed in the atlas)
+				newFontName = "font_"+fontName.toLowerCase().replace(" ", "_") +"_"+selectSize.getSelected()+"pt";
+				if (checkBold.isChecked() == true) {
+					newFontName += "_bold";
+				}
+				
+				if (checkItalic.isChecked() == true) {
+					newFontName += "_italic";
+				}
+				
+				textFontName.setText(newFontName);
 			}
-			
-			if (checkItalic.isChecked() == true) {
-				newFontName += "_italic";
-			}
-			
-			textFontName.setText(newFontName);
-	
 			
 			// Create bitmap font
 			BMFontUtil bfu = new BMFontUtil(unicodeFont);

--- a/core/src/org/shadebob/skineditor/actors/MenuBar.java
+++ b/core/src/org/shadebob/skineditor/actors/MenuBar.java
@@ -190,7 +190,7 @@ public class MenuBar extends Table {
 					
 					FileHandle projectFolder = Gdx.files.local("projects").child(game.screenMain.getcurrentProject());
 					for(FileHandle file : projectFolder.list()) {
-						if (file.name().startsWith("uiskin.") || (file.extension() == "fnt")) {
+						if (file.name().startsWith("uiskin.") || (file.extension().equalsIgnoreCase("fnt"))) {
 							Gdx.app.log("MenuBar","Copying file: " + file.name() + " ...");
 							FileHandle target = targetDirectory.child(file.name());
 							file.copyTo(target);

--- a/core/src/org/shadebob/skineditor/actors/PreviewPane.java
+++ b/core/src/org/shadebob/skineditor/actors/PreviewPane.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.ImageButton;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.List;
 import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
+import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar.ProgressBarStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Slider;
@@ -175,7 +176,14 @@ public class PreviewPane extends Table {
 
 					} else if (widget.equals("ProgressBar")) { // ProgressBar
 
-						ProgressBar w = new ProgressBar(0, 100, 5, false, game.skinProject, key);
+						ProgressBarStyle progressStyle = game.skinProject.get(key, ProgressBarStyle.class);
+						
+						// Check for edge-case: fields knob and knobBefore are optional but at least one should be specified
+						if(progressStyle.knob == null && progressStyle.knobBefore == null) {
+							throw new IllegalArgumentException("Fields 'knob' and 'knobBefore' in ProgressBarStyle are both optional but at least one should be specified");
+						}
+						
+						ProgressBar w = new ProgressBar(0, 100, 5, false, progressStyle);
 						w.setValue(50);
 						w.addListener(stopTouchDown);
 


### PR DESCRIPTION
When any ProgressBarStyle lacks knob **and** knobBefore, switching to ProgressBar tab in the MenuBar will make the UI crash.

Here a fix for that.

Well, there's also a pretty standard *.gitignore* file included, as there wasn't any.