### PR TITLE
Mac OS X font path added

### DIFF
--- a/core/src/org/shadebob/skineditor/SystemFonts.java
+++ b/core/src/org/shadebob/skineditor/SystemFonts.java
@@ -56,6 +56,7 @@ public class SystemFonts {
 			
 			fontPaths.add("/Network/Library/Fonts/");
 			fontPaths.add("~/Library/Fonts/");
+			fontPaths.add("/Library/Fonts/");
 		}
 		
 	}


### PR DESCRIPTION
For me this path works.
spec: Yosemite 10.10.5, Java 8
